### PR TITLE
feat: Update scikit-build-core settings enabling cmake verbosity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ build-dir = "build/{wheel_tag}"
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 sdist.include = ["src/s5cmd/_version.py"]
 wheel.py-api = "py3"
+cmake.verbose = true
+logging.level = "INFO"
 
 
 [tool.setuptools_scm]
@@ -77,6 +79,7 @@ write_to = "src/s5cmd/_version.py"
 test-command = "pytest {project}/tests"
 test-extras = ["test"]
 test-skip = ["*universal2:arm64"]
+build-verbosity = 1
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
See https://scikit-build-core.readthedocs.io/en/latest/configuration.html#verbosity
and https://cibuildwheel.pypa.io/en/stable/options/#build-verbosity